### PR TITLE
fix import of typings in python 3.7 (PEP 560)

### DIFF
--- a/dataclasses_serialization/serializer_base.py
+++ b/dataclasses_serialization/serializer_base.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass, fields, asdict, is_dataclass
 from functools import partial
-from typing import TypeVar, Union, GenericMeta, Dict, List
+from typing import TypeVar, Union, Dict, List
+try:
+    from typing import GenericMeta  # python 3.6
+except ImportError:
+    class GenericMeta(type): pass # python 3.7
 
 from typing_inspect import get_args
 


### PR DESCRIPTION
`GenericMeta` was removed in Python 3.7 (see: PEP 560, https://www.python.org/dev/peps/pep-0560/). 
We just check, if `GenericMeta` is available (<=3.6), and if it's not we just create a class for backwards compatibility. 