### PR TITLE
Use get_type_hints to resolve field types

### DIFF
--- a/dataclasses_serialization/serializer_base.py
+++ b/dataclasses_serialization/serializer_base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields, is_dataclass
 from functools import partial
-from typing import TypeVar, Union, Dict, List
+from typing import TypeVar, Union, Dict, List, get_type_hints
 
 from typing_inspect import is_union_type, get_origin, get_args
 
@@ -116,8 +116,9 @@ def dict_to_dataclass(cls, dct, deserialization_func=noop_deserialization):
             for fld in flds
         )
     else:
+        type_hints = get_type_hints(cls)
         flds = fields(cls)
-        fld_types = (fld.type for fld in flds)
+        fld_types = (type_hints[fld.name] for fld in flds)
 
     try:
         return cls(**{


### PR DESCRIPTION
This commit fixes dataclasses_serialization for users who try to use
`from __future__ import annotations` in their code.

Adding the import enables features described in
https://www.python.org/dev/peps/pep-0563/, but it changes the Field
class from dataclasses module, that dataclasses_serialization depends
on. With annotations imported, the `type` field of Field class becomes
a string with a name of a type, rather then the type (as it is now).
I changed the field type resulution logic to call get_type_hints method
from typing, instead of depending on the type stored in Field class.

For example, the following code would break previously:

```
from __future__ import annotations
from dataclasses import dataclass
from dataclasses_serialization.json import JSONSerializer

@dataclass
class Foo:
    x: int

JSONSerializer.deserialize(Foo, {'x': 42})
```

Exception:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/dataclasses_serialization/serializer_base.py", line 125, in dict_to_dataclass
    for fld, fld_type in zip(flds, fld_types)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/dataclasses_serialization/serializer_base.py", line 126, in <dictcomp>
    if fld.name in dct
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/toolz/functoolz.py", line 303, in __call__
    return self._partial(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/dataclasses_serialization/serializer_base.py", line 234, in deserialize
    if issubclass(cls, type_):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/dataclasses_serialization/serializer_base.py", line 72, in issubclass
    return original_issubclass(cls, classinfo)
TypeError: issubclass() arg 1 must be a class

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 9, in <module>
    JSONSerializer.deserialize(Foo, {'x': 42})
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/toolz/functoolz.py", line 303, in __call__
    return self._partial(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/dataclasses_serialization/serializer_base.py", line 238, in deserialize
    return self.deserialization_functions[dataclass](cls, serialized_obj)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/toolz/functoolz.py", line 303, in __call__
    return self._partial(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/dataclasses_serialization/serializer_base.py", line 131, in dict_to_dataclass
    cls
dataclasses_serialization.serializer_base.DeserializationError: Missing one or more required fields to deserialize {'x': 42} as <class '__main__.Foo'>
```