### PR TITLE
depend on dataclasses package only for python<3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dataclasses
+dataclasses ; python_version < '3.7'
 more_properties>=1.1.0
 typing_inspect
 toolz


### PR DESCRIPTION
As of python3.7 dataclasses is built in to python
dataclasses package even changed their supported versions after 0.6 to `>=3.6, <3.7`
That means if we keep the dataclasses requirement we are stuck using dataclasses<=0.6 and don't use the built-in

Adding the suffix here will make sure we can use the built-in dataclasses

Currently we still get the requirement from `more_properties`, which is why I also opened PR to change it there:
https://github.com/madman-bob/python-more-properties/pull/1